### PR TITLE
Allow duplicate category values in Pie charts.

### DIFF
--- a/SVGGraphPieGraph.php
+++ b/SVGGraphPieGraph.php
@@ -100,10 +100,9 @@ class PieGraph extends Graph {
 
     // need to store the original position of each value, because the
     // sorted list must still refer to the relevant legend entries
-    $position = 0;
     $values = array();
-    foreach($this->values[0] as $item) {
-      $values[$item->key] = array($position++, $item->value, $item);
+    foreach($this->values[0] as $position => $item) {
+      $values[] = array($position, $item->value, $item);
       if(!is_null($item->value))
         ++$vcount;
     }
@@ -114,12 +113,13 @@ class PieGraph extends Graph {
     $slice = 0;
     $slices = array();
     $slice_no = 0;
-    foreach($values as $key => $value) {
+    foreach($values as $value) {
 
       // get the original array position of the value
       $original_position = $value[0];
       $item = $value[2];
       $value = $value[1];
+      $key = $item->key;
       if($this->legend_show_empty || $item->value != 0) {
         $attr = array('fill' => $this->GetColour($item, $slice, NULL, true,
           true));


### PR DESCRIPTION
Hi Graham,

we had a few users that tried to plot pie chars with duplicate category names which ended up in half eaten pies. This patch should resolve the issue.

Cheers,
Petr
