### PR TITLE
Added check for difference between decimal and thousands separator settings

### DIFF
--- a/SVGGraph.php
+++ b/SVGGraph.php
@@ -1521,9 +1521,14 @@ abstract class Graph {
 
   /**
    * Sets the number format characters
+   *
+   * @throws LogicException if $decimal and $thousands parameters are equal.
    */
   public static function SetNumStringOptions($decimal, $thousands)
   {
+    if ($decimal === $thousands) {
+      throw new LogicException(sprintf('Decimal and thousand separator must not be equal. Please use different settings for "thousands" and "decimal".'));
+    }
     Graph::$decimal = $decimal;
     Graph::$thousands = $thousands;
   }


### PR DESCRIPTION
I had the problem that I only changed the thousand separator to `.` (it's the German style) but that leads to the trimming of all zeros of the axis labels, because the decimal separator is `.` per default, too. So that for example numbers like `4000` where trimmed to `4`. And I thought it was a bug in the library until I started debuging.

This is why I added the check to `Graph::SetNumStringOptions()`, so that this cannot happen anymore.