### PR TITLE
Fix disappearing axis label.

### DIFF
--- a/DisplayAxis.php
+++ b/DisplayAxis.php
@@ -391,7 +391,7 @@ class DisplayAxis {
       for($p = 0; $p < $count; ++$p) {
 
         $point = $points[$p];
-        if($point->text == '')
+        if($point->text === '')
           continue;
 
         $labels .= $this->getText($x + $x_offset, $y + $y_offset, $point,


### PR DESCRIPTION
If the label is '0' or 0 (force_assoc), it did not show on axis.

Fixes #31.