### PR TITLE
Adjusted property/method visibility to make Legend and PointGraph more extensible

### DIFF
--- a/Legend.php
+++ b/Legend.php
@@ -26,35 +26,35 @@ namespace Goat1000\SVGGraph;
  */
 class Legend {
 
-  private $graph;
-  private $entry_details = [];
-  private $autohide;
-  private $back_colour;
-  private $colour;
-  private $columns;
-  private $draggable;
-  private $entries;
-  private $entry_height;
-  private $entry_width;
-  private $font;
-  private $font_adjust;
-  private $font_size;
-  private $font_weight;
-  private $padding;
-  private $position;
-  private $round;
-  private $shadow_opacity;
-  private $show_empty;
-  private $stroke_colour;
-  private $stroke_width;
-  private $text_side;
-  private $title;
-  private $title_colour;
-  private $title_font;
-  private $title_font_adjust;
-  private $title_font_size;
-  private $title_font_weight;
-  private $type;
+  protected $graph;
+  protected $entry_details = [];
+  protected $autohide;
+  protected $back_colour;
+  protected $colour;
+  protected $columns;
+  protected $draggable;
+  protected $entries;
+  protected $entry_height;
+  protected $entry_width;
+  protected $font;
+  protected $font_adjust;
+  protected $font_size;
+  protected $font_weight;
+  protected $padding;
+  protected $position;
+  protected $round;
+  protected $shadow_opacity;
+  protected $show_empty;
+  protected $stroke_colour;
+  protected $stroke_width;
+  protected $text_side;
+  protected $title;
+  protected $title_colour;
+  protected $title_font;
+  protected $title_font_adjust;
+  protected $title_font_size;
+  protected $title_font_weight;
+  protected $type;
 
   public function __construct(&$graph)
   {
@@ -309,7 +309,7 @@ class Legend {
   /**
    * Returns the list of entries in the correct order
    */
-  private function getEntries()
+  protected function getEntries()
   {
     $entry_order = $this->graph->getOption('legend_order');
     if($entry_order === null || $entry_order == 'auto')

--- a/PointGraph.php
+++ b/PointGraph.php
@@ -26,10 +26,10 @@ namespace Goat1000\SVGGraph;
  */
 abstract class PointGraph extends GridGraph {
 
-  private $markers = [];
-  private $marker_ids = [];
-  private $marker_link_ids = [];
-  private $marker_types = [];
+  protected $markers = [];
+  protected $marker_ids = [];
+  protected $marker_link_ids = [];
+  protected $marker_types = [];
 
   /**
    * Changes to crosshair cursor by overlaying a transparent rectangle
@@ -100,7 +100,7 @@ abstract class PointGraph extends GridGraph {
   /**
    * Returns a marker element
    */
-  private function getMarker($marker, $set)
+  protected function getMarker($marker, $set)
   {
     $id = isset($marker->id) ? $marker->id : $this->marker_ids[$set];
     $use = ['x' => $marker->x, 'y' => $marker->y];
@@ -155,7 +155,7 @@ abstract class PointGraph extends GridGraph {
   /**
    * Creates a single marker element and its link version
    */
-  private function createMarker($type, $size, $fill, $stroke_width,
+  protected function createMarker($type, $size, $fill, $stroke_width,
     $stroke_colour, $opacity, $angle)
   {
     $m_key = serialize(func_get_args());
@@ -180,7 +180,7 @@ abstract class PointGraph extends GridGraph {
   /**
    * Returns true if a marker is different to others in its set
    */
-  private function specialMarker($set, &$item)
+  protected function specialMarker($set, &$item)
   {
     $null_item = null;
     if($this->getItemOption('marker_colour', $set, $item, 'colour') !=
@@ -199,7 +199,7 @@ abstract class PointGraph extends GridGraph {
   /**
    * Creates a single marker for the data set
    */
-  private function createSingleMarker($set, &$item = null)
+  protected function createSingleMarker($set, &$item = null)
   {
     $type = $this->getItemOption('marker_type', $set, $item);
     $size = $this->getItemOption('marker_size', $set, $item);
@@ -227,7 +227,7 @@ abstract class PointGraph extends GridGraph {
   /**
    * Creates the marker types
    */
-  private function createMarkers()
+  protected function createMarkers()
   {
     foreach(array_keys($this->markers) as $set) {
       // set the ID for this data set to use


### PR DESCRIPTION
Hopefully outlining my specific use case will provide some context for this PR...

I needed to create a ScatterGraph where colour and marker size represent values, alongside those represented on the X and Y axis. 

- X = Value 1
- Y = Value 2
- Colour = Value 3
- Marker Size = Value 4

This was all possible with the standard configuration options using structured data. Thanks! 

However, I then needed the legend to contain entries to label the colours/markers used to represent Values 3 and 4. In order to do this I needed to:

- ensure that any values repeated within the dataset were represented by a single entry within the legend 
- remove sizing from the "Colour" symbols within the legend (to avoid confusion with Value 4)
- remove colours from the "Marker Size" symbols in the legend (to avoid confusion with Value 3)

This is all made achievable by extening `Goat1000\SVGGraph\ScatterGraph` (with custom `initLegend` and `drawLegendEntry` methods) and `Goat1000\SVGGraph\Legend` (with  custom `setEntry` / `getEntries` methods). 

The customisations themselves were fairly straightforward, but overriding the default functionality from a child wasn't possible as due to the use of `private` visibility within those classes. I've proposed changing the visibility to `protected` on those classes, so that they can be extended and customised with minimal pain, without exposing internal methods publically.

