### PR TITLE
AxisDateTime: use local timezone instead of UTC

### DIFF
--- a/AxisDateTime.php
+++ b/AxisDateTime.php
@@ -610,7 +610,8 @@ class AxisDateTime extends Axis {
   public function dateText($f)
   {
     $dt = new \DateTime('@' . $f);
-    return $dt->format($this->axis_text_format);
+    return $dt->setTimezone(new \DateTimeZone(date_default_timezone_get()))
+      ->format($this->axis_text_format);
   }
 
   /**


### PR DESCRIPTION
[`DateTime::__construct()`][1] takes two parameters: `$time` and `$timezone`. I will skip the second one as it was not used in [`AxisDateTime::dateText()`][2]. As said in [the PHP Manual][3], if `$time` is a string containing an ‘@’‑prefixed UNIX timestamp, then the current (server­‑local) timezone is ignored and the new `DateTime` object has UTC set as its timezone. That is the way `dateText()` used to work.

For example, if 2020-05-01T12:00+02:00 was passed to SVGGraph (on a server in the +02:00 timezone), it would be rendered as 2020-05-01 10:00, because that would be the time in UTC. I think it should be rendered as 2020-05-01 12:00 instead.

This PR adds a call to [`DateTime::setTimezone()`][4] in order to set the local timezone (as returned by [`date_default_timezone_get()`][5]) on the `DateTime` object.

This PR replaces #42.

[1]: https://www.php.net/manual/en/datetime.construct.php
[2]: https://github.com/goat1000/SVGGraph/blob/1bde939609e3391aed921015cc5bf47cbfe103f5/AxisDateTime.php#L610
[3]: https://www.php.net/manual/en/datetime.construct.php#refsect1-datetime.construct-parameters
[4]: https://www.php.net/manual/en/datetime.settimezone.php
[5]: https://www.php.net/manual/en/function.date-default-timezone-get