### PR TITLE
Ignore errors/warnings/notices for the iconv test

### DIFF
--- a/Text.php
+++ b/Text.php
@@ -46,7 +46,7 @@ class Text {
       if($graph->getOption('use_iconv', true) && extension_loaded('iconv')) {
         // test the iconv function
         $test_euro = "Test:\u{20ac}";
-        $out = iconv('UTF-8', 'ASCII//TRANSLIT', $test_euro);
+        $out = @iconv('UTF-8', 'ASCII//TRANSLIT', $test_euro);
         Text::$use_iconv = (strlen($out) > 0);
       }
     }


### PR DESCRIPTION
This operation fails for me and is the only call that does not suppress the notice when executing.